### PR TITLE
enables flow callable generics syntax

### DIFF
--- a/packages/extract-react-types/__snapshots__/test.js.snap
+++ b/packages/extract-react-types/__snapshots__/test.js.snap
@@ -1218,7 +1218,24 @@ Object {
 exports[`flow forwardRef callable type arguments 1`] = `
 Object {
   "component": Object {
-    "kind": "any",
+    "kind": "generic",
+    "value": Object {
+      "kind": "object",
+      "members": Array [
+        Object {
+          "key": Object {
+            "kind": "id",
+            "name": "name",
+          },
+          "kind": "property",
+          "optional": false,
+          "value": Object {
+            "kind": "string",
+          },
+        },
+      ],
+      "referenceIdName": "Props",
+    },
   },
   "kind": "program",
 }

--- a/packages/extract-react-types/__snapshots__/test.js.snap
+++ b/packages/extract-react-types/__snapshots__/test.js.snap
@@ -1215,6 +1215,15 @@ Object {
 }
 `;
 
+exports[`flow forwardRef callable type arguments 1`] = `
+Object {
+  "component": Object {
+    "kind": "any",
+  },
+  "kind": "program",
+}
+`;
+
 exports[`flow forwardRef default export 1`] = `
 Object {
   "component": Object {

--- a/packages/extract-react-types/src/index.js
+++ b/packages/extract-react-types/src/index.js
@@ -1451,7 +1451,7 @@ function getContext(typeSystem: 'flow' | 'typescript', filename?: string, resolv
   }
 
   if (typeSystem === 'flow') {
-    plugins.push('flow');
+    plugins.push(['flow', { all: true }]);
   } else if (typeSystem === 'typescript') {
     plugins.push('typescript');
 

--- a/packages/extract-react-types/test.js
+++ b/packages/extract-react-types/test.js
@@ -1383,6 +1383,23 @@ const TESTS = [
     `
   },
   {
+    name: 'flow forwardRef callable type arguments',
+    typeSystem: 'flow',
+    code: `
+      type Props = {
+        name: string,
+      }
+
+      function Component (props: Props) {};
+
+      Component.defaultProps = {
+        name: 'bob',
+      };
+
+      export default React.forwardRef<Props, HTMLElement>((props, ref) => <Component {...props} ref={ref} />);
+    `
+  },
+  {
     name: 'flow default class export',
     typeSystem: 'flow',
     code: `

--- a/packages/extract-react-types/test.js
+++ b/packages/extract-react-types/test.js
@@ -33,7 +33,7 @@ const TESTS = [
         and: true && 'something',
       }
     }
-    
+
   `
   },
   {
@@ -45,7 +45,7 @@ const TESTS = [
         or: 'me' || 'you',
       }
     }
-    
+
   `
   },
   {
@@ -415,9 +415,9 @@ const TESTS = [
     interface BadgeProps {
       texture: string;
     }
-    
+
     function Badge({ texture }: BadgeProps) {}
-    
+
     Badge.f = [];
 
     export default Badge;
@@ -430,7 +430,7 @@ const TESTS = [
     interface BadgeProps {
       texture: Texture["src"];
     }
-    
+
     function Badge({ texture }: BadgeProps) {}
 
     export default Badge;
@@ -460,7 +460,7 @@ const TESTS = [
     export class Theme extends React.Component<{}, {}> {
       @Field(_ => ID)
       public id!: string;
-    
+
       @Field(_ => Textures)
       public fonts!: Textures;
 
@@ -1396,7 +1396,7 @@ const TESTS = [
         name: 'bob',
       };
 
-      export default React.forwardRef<Props, HTMLElement>((props, ref) => <Component {...props} ref={ref} />);
+      export default React.forwardRef<Props, HTMLElement>((props: Props, ref) => <Component {...props} ref={ref} />);
     `
   },
   {
@@ -1422,27 +1422,27 @@ const TESTS = [
     type Props = {
       ok: number
     }
-    
+
     class FieldInner extends React.Component<Props> {
       unregisterField = () => {};
-    
+
       componentDidMount() {
         this.unregisterField = this.register();
       }
-    
+
       componentWillUnmount() {
         this.unregisterField();
       }
     }
-    
+
     const Field = (props: Props) => <FieldInner {...props} />;
-    
+
     Field.defaultProps = {
       ok: 1
     };
-    
+
     export default Field;
-    
+
     `
   },
   {
@@ -1459,7 +1459,7 @@ const TESTS = [
 
     export default SomeComponent
 
-    
+
     `
   },
   {
@@ -1475,7 +1475,7 @@ const TESTS = [
     })
 
     export default SomeComponent
-    
+
     `
   },
   {
@@ -1491,7 +1491,7 @@ const TESTS = [
     }
 
     export default SomeComponent
-    
+
     `
   },
   {
@@ -1507,7 +1507,7 @@ const TESTS = [
     })
 
     export default SomeComponent
-    
+
     `
   },
   {
@@ -1523,7 +1523,7 @@ const TESTS = [
     })
 
     export default SomeComponent
-    
+
     `
   },
   {
@@ -1539,7 +1539,7 @@ const TESTS = [
     })
 
     export default SomeComponent
-    
+
     `
   },
   {
@@ -1555,7 +1555,7 @@ const TESTS = [
     }))
 
     export default SomeComponent
-    
+
     `
   },
   {
@@ -1602,7 +1602,7 @@ const TESTS = [
     typeSystem: 'flow',
     code: `
     type Props = { bar: string }
-  
+
     class Component extends React.Component<Props> {
       static defaultProps = {
         bar: (ascii: string),


### PR DESCRIPTION
Passes all=true option to flow plugin as defined in babel-parser docs
here: https://babeljs.io/docs/en/next/babel-parser.html#plugins-options.

Doing so enables the syntax defined in the flow docs here:
https://flow.org/en/docs/types/generics/#toc-function-types-with-generics

Example: `<T>(param: T) => T`